### PR TITLE
feat(research): add derivative_ticker support to query API

### DIFF
--- a/pointline/research/query.py
+++ b/pointline/research/query.py
@@ -361,6 +361,7 @@ def derivative_ticker(
     *,
     ts_col: str = "ts_local_us",
     columns: list[str] | tuple[str, ...] | None = None,
+    decoded: bool = False,
     lazy: bool = True,
 ) -> pl.LazyFrame | pl.DataFrame:
     """Load derivative ticker data with automatic symbol resolution.
@@ -378,6 +379,7 @@ def derivative_ticker(
         end: End time (datetime, ISO string, or int microseconds)
         ts_col: Timestamp column to filter on (default: "ts_local_us")
         columns: List of columns to select (default: all)
+        decoded: Ignored for derivative_ticker (data is already float, default: False)
         lazy: Return LazyFrame (True) or DataFrame (False)
 
     Returns:
@@ -404,6 +406,10 @@ def derivative_ticker(
         ...     lazy=False,
         ... )
     """
+    # Note: `decoded` is accepted for API consistency with trades/quotes/book_snapshot_25,
+    # but derivative_ticker data is stored as Float64 (not fixed-point), so no decoding is needed.
+    del decoded  # Unused - derivative_ticker is already float
+
     start_ts_us = core._normalize_timestamp(start, "start")
     end_ts_us = core._normalize_timestamp(end, "end")
 


### PR DESCRIPTION
## Summary

Add `derivative_ticker` support to the research query API for loading derivative ticker data (funding rates, open interest, mark/index prices).

## Changes

- **core.py**: Add `load_derivative_ticker()` - low-level API with explicit `symbol_id`
- **query.py**: Add `derivative_ticker()` - high-level convenience API with auto symbol resolution
- Added `decoded` parameter (no-op) for API consistency with other query functions

## Usage

```python
from pointline.research import query

# High-level API (convenience)
ticker = query.derivative_ticker(
    exchange="binance-futures",
    symbol="SOLUSDT",
    start="2024-05-01",
    end="2024-05-02",
)

# Low-level API (production use)
from pointline.research import core
ticker = core.load_derivative_ticker(
    symbol_id=101,
    start_ts_us=1700000000000000,
    end_ts_us=1700003600000000,
)
```

## Data Included
- `funding_rate` / `predicted_funding_rate`
- `open_interest`
- `mark_px` / `index_px` / `last_px`
- `funding_ts_us`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **API Updates**
  * Updated `derivative_ticker` function signature to accept an additional parameter for future compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->